### PR TITLE
Add legacy authentication option

### DIFF
--- a/src/qml/Main.qml
+++ b/src/qml/Main.qml
@@ -24,6 +24,7 @@ Kirigami.ApplicationWindow {
     property string _serverURL: ""
     property string _username: ""
     property string _password: ""
+    property bool _legacyAuth: false
     property int mpHeight: mediaPlayer.height
     property bool _displayMessage: false
     property string _messageText: ""
@@ -213,6 +214,7 @@ Kirigami.ApplicationWindow {
         _serverURL = Helper.getSetting("serverURL", "");
         _username = Helper.getSetting("username", "");
         _password = Helper.getSetting("password", "");
+        _legacyAuth = Helper.getSetting("legacyAuth", false);
 
         _offlineMode = Helper.getSetting("offlineMode", false);
 
@@ -257,8 +259,14 @@ Kirigami.ApplicationWindow {
         if (path.indexOf("?") > 0) {
             qry = "&";
         }
-
-        return _serverURL + "/rest/" + path + qry + "u=" + _username + "&t=" + Helper.md5(_password + salt) + "&s=" + salt + "&v=1.16.0" + "&c=supersonik"
+        
+        if (_legacyAuth) {
+            return _serverURL + "/rest/" + path + qry + "u=" + _username + "&p=" + _password + "&v=1.15.0" + "&c=supersonik"
+        }
+        else {
+            return _serverURL + "/rest/" + path + qry + "u=" + _username + "&t=" + Helper.md5(_password + salt) + "&s=" + salt + "&v=1.16.0" + "&c=supersonik"
+        }
+        
     }
 
     function attributeValue(node, attribute) {

--- a/src/qml/pages/SettingsPage.qml
+++ b/src/qml/pages/SettingsPage.qml
@@ -56,6 +56,18 @@ Kirigami.ScrollablePage {
                 echoMode: TextInput.PasswordEchoOnEdit
             }
 
+            FormCard.FormDelegateSeparator {}
+
+            FormCard.FormCheckDelegate {
+                id:chkLegacyAuth
+                text: i18n("Use Legacy Authentication")
+                onToggled: {
+                    _legacyAuth = checkState
+
+                    saveSettings();
+                }
+            }
+
             FormCard.FormDelegateSeparator { above: btnContinue }
 
             FormCard.FormButtonDelegate {
@@ -65,6 +77,7 @@ Kirigami.ScrollablePage {
                     _serverURL = txtServerURL.text;
                     _username = txtUsername.text;
                     _password = txtPassword.text;
+                    _legacyAuth = chkLegacyAuth.checkState;
 
                     saveSettings();
 
@@ -113,8 +126,9 @@ Kirigami.ScrollablePage {
         _serverURL = Helper.getSetting("serverURL", "");
         _username = Helper.getSetting("username", "");
         _password = Helper.getSetting("password", "");
+        _legacyAuth = Helper.getSetting("legacyAuth", false);
 
-        console.log(_serverURL, _username, _password);
+        console.log(_serverURL, _username, _password, _legacyAuth);
 
         if (_serverURL != "") {
             txtServerURL.text = _serverURL;
@@ -127,6 +141,10 @@ Kirigami.ScrollablePage {
         if (_password != "") {
             txtPassword.text = _password;
         }
+
+        if (_legacyAuth) {
+            chkLegacyAuth.checkState = Qt.Checked;
+        }
     }
 
     function saveSettings() {
@@ -134,7 +152,8 @@ Kirigami.ScrollablePage {
         Helper.setSetting("serverURL", _serverURL);
         Helper.setSetting("username", _username);
         Helper.setSetting("password", _password);
+        Helper.setSetting("legacyAuth", _legacyAuth);
 
-        console.log(_serverURL, _username, _password);
+        console.log(_serverURL, _username, _password, _legacyAuth);
     }
 }


### PR DESCRIPTION
This adds an option for legacy plaintext authentication with a lower API version to work with airsonic-advanced.