### PR TITLE
Last.fm album art

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,7 @@ ecm_add_qml_module(supersonik
     qml/Main.qml
     qml/pages/SettingsPage.qml
     qml/pages/MusicFeed.qml
+    qml/components/AlbumArt.qml
     qml/components/MediaPlayer.qml
     qml/components/OfflineFiles.qml
     RESOURCES

--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -1,3 +1,4 @@
+#include <QRegularExpression>
 #include "fileio.h"
 
 bool FileIO::write(const QString &source, const QByteArray& data)
@@ -19,8 +20,8 @@ bool FileIO::write(const QString &source, const QByteArray& data)
         qDebug() << "Unable to open file for write";
         return false;
     }
-    QDataStream out(&file);
-    out << data;
+
+    file.write(data);
     file.close();
     return true;
 }
@@ -38,6 +39,38 @@ bool FileIO::rm(const QString &source)
         return f.remove();
     }
     return false;
+}
+
+QString FileIO::makeFilename(QString input)
+{  
+    QString output = input;
+    output.remove(QRegularExpression(QString::fromUtf8("[`~!@#$%^&*()—+=|:;<>«»,?/{}\'\"\\[\\]\\\\]")));
+    return output;
+}
+
+QString FileIO::findFilePath(const QString &source)
+{
+    qDebug() << Q_FUNC_INFO << source;
+    if (source.isEmpty())
+        return QString();
+
+    QString cacheDir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + QStringLiteral("/cache/");
+
+    QDir d(cacheDir);
+
+    QStringList filter;
+    filter << (source + QString::fromUtf8("*"));
+    d.setNameFilters(filter);
+
+    if(d.entryList().size() > 0)
+    {
+        QFile f(cacheDir + d.entryList()[0]);
+        if (f.exists()) {
+            qDebug() << QLatin1String(f.filesystemFileName().c_str());
+            return QLatin1String(f.filesystemFileName().c_str());
+        }
+    }
+    return QString();
 }
 
 QString FileIO::filePath(const QString &source)

--- a/src/fileio.h
+++ b/src/fileio.h
@@ -14,7 +14,9 @@ class FileIO : public QObject
 public Q_SLOTS:
     bool write(const QString& source, const QByteArray& data);
     bool rm(const QString& source);
+    QString findFilePath(const QString &source);
     QString filePath(const QString& source);
+    QString makeFilename(QString input);
 
 public:
     FileIO() {}

--- a/src/qml/Main.qml
+++ b/src/qml/Main.qml
@@ -205,6 +205,10 @@ Kirigami.ApplicationWindow {
         }
     }
 
+    AlbumArt {
+        id: albumArt
+    }
+    
     OfflineFiles {
         id: offlineFiles
     }

--- a/src/qml/components/AlbumArt.qml
+++ b/src/qml/components/AlbumArt.qml
@@ -1,0 +1,99 @@
+// Includes relevant modules used by the QML
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Controls as Controls
+import org.kde.kirigami as Kirigami
+import uk.co.piggz 1.0
+import uk.co.piggz.supersonik
+
+Item {
+    id: albumArt
+
+    function getElementsByTagName(rootElement, tagName, elements) {
+        var childNodes = rootElement.childNodes;
+        for(var i = 0; i < childNodes.length; i++) {
+            if(childNodes[i].nodeName === tagName) {
+                elements.push(childNodes[i]);
+            }
+            if(childNodes[i].childNodes.length > 0) {
+                getElementsByTagName(childNodes[i], tagName, elements)    
+            }
+        }
+        return elements;
+    }
+
+    function downloadComplete(xhr, callback, albumid) {
+        if (FileIO.write(xhr.param, xhr.response)) {
+            callback(albumid, "file:" + FileIO.filePath(xhr.param))
+        } else {
+            showMessage("Error saving " + xhr.param);
+        }
+    }
+
+    function getUrlExtension( url ) {
+        return url.split(/[#?]/)[0].split('.').pop().trim();
+    }
+
+    function onLastFmCoverArtResponse(artist, album, imageSize, response, callback, albumid) {
+        var elements = []
+        getElementsByTagName(response, "image", elements)
+        for(var i = 0; i < elements.length; i++) {
+            if(elements[i].attributes[0].name === "size" && elements[i].attributes[0].value === imageSize) {
+                var url = elements[i].childNodes[0].nodeValue
+                var extension = getUrlExtension(url)
+
+                var xhr = new XMLHttpRequest()
+                xhr.param = FileIO.makeFilename(artist + "_" + album + "." + extension)
+                xhr.responseType = "arrayBuffer"
+                xhr.onreadystatechange = (function (response) {
+                    return function () {
+                        if (xhr.readyState === XMLHttpRequest.DONE) {
+                            downloadComplete(xhr, callback, albumid)
+                        }
+                    }
+                })(xhr)
+                xhr.open("GET", url, true)
+                xhr.send('')
+            }
+        }
+    }
+    
+    function fetchLastFmCoverArtUrl(artist, album, albumid, callback) {
+        var xhr = new XMLHttpRequest()
+        const apiKey = "3e7c3f82073cfd0317d71eab70657d7e";
+        const imageSize = "mega";
+        const method = "album.getinfo";
+        const request = "http://ws.audioscrobbler.com/2.0/?method=" + method + "&api_key=" + apiKey + "&artist=" + artist.replace(" ", "%20") + "&album=" + album.replace(" ", "%20");
+
+        xhr.onreadystatechange = (function (response) {
+            return function () {
+                if (xhr.readyState === XMLHttpRequest.DONE) {
+                    onLastFmCoverArtResponse(artist, album, imageSize, xhr.responseXML.documentElement, callback, albumid)
+                }
+            }
+        })(xhr)
+        xhr.open("GET", request, true)
+        xhr.send('')
+
+        return ""
+    }
+
+    function getAlbumArtUrl(coverArt, artist, album, albumid, callback) {
+        var url = Qt.resolvedUrl("../pics/cassette.png")
+        
+        if(coverArt) {
+            url = buildSubsonicUrl("getCoverArt?id=" + coverArt)
+        }
+        else {
+            var cached_url = FileIO.findFilePath(FileIO.makeFilename(artist + "_" + album))
+
+            if(cached_url) {
+                url = "file:" + cached_url
+            }
+            else if(callback) {
+                fetchLastFmCoverArtUrl(artist, album, albumid, callback)
+            }
+        }
+        return new URL(url) 
+    }
+}

--- a/src/qml/pages/MusicFeed.qml
+++ b/src/qml/pages/MusicFeed.qml
@@ -173,7 +173,7 @@ Kirigami.ScrollablePage {
 
             ]
             banner {
-                source: coverArt ? buildSubsonicUrl("getCoverArt?id=" + coverArt) : Qt.resolvedUrl("../pics/cassette.png")
+                source: artUrl
                 title: title
                 implicitHeight: width
                 titleAlignment: Qt.AlignLeft | Qt.AlignBottom
@@ -190,7 +190,6 @@ Kirigami.ScrollablePage {
                 }
             }
         }
-
     }
 
     Component {
@@ -337,9 +336,17 @@ Kirigami.ScrollablePage {
 
                     console.log(song.nodeName);
                     if ( song.nodeName ===  "album") {
-                        albums.append({"title": attributeValue(song, "title"), "artist": attributeValue(song, "artist"),
-                                          "year": attributeValue(song, "year"),"albumid": attributeValue(song, "id"),
-                                          "coverArt": attributeValue(song, "coverArt"), "starred": attributeValue(song, "starred")})
+                        var title = attributeValue(song, "title")
+                        if(!title) {
+                            title = attributeValue(song, "name")
+                        }
+                        var coverArt = attributeValue(song, "coverArt")
+                        var artist = attributeValue(song, "artist")
+                        var albumid = attributeValue(song, "id")
+                        albums.append({"title": title, "artist": artist,
+                                          "year": attributeValue(song, "year"),"albumid": albumid,
+                                          "coverArt": attributeValue(song, "coverArt"), "starred": attributeValue(song, "starred"),
+                                          "artUrl": albumArt.getAlbumArtUrl(coverArt, artist, title, albumid, updateAlbumArt)})
                     }
 
                 }
@@ -426,6 +433,14 @@ Kirigami.ScrollablePage {
                 if (albums.get(i).albumid === albumId) {
                     albums.setProperty(i, "starred", "true");
                 }
+            }
+        }
+    }
+
+    function updateAlbumArt(albumId, newArtUrl) {
+        for( var i = 0; i < albums.rowCount(); i++ ) {
+            if (albums.get(i).albumid === albumId) {
+                albums.setProperty(i, "artUrl", newArtUrl);
             }
         }
     }


### PR DESCRIPTION
This PR reworks how album art is handled.  Previously, album art was only pulled from the Subsonic server and if no art was available for a given album, a default image of a cassette would be used instead.  Now, when the artwork is not available from the server and it is not already cached in the application's .local directory, Supersonik will send a request to the Last.fm [album.getinfo](https://www.last.fm/api/show/album.getInfo) API containing the artist and album names and retrieve the artwork from Last.fm if it is available.  After the artwork is retrieved it is saved in the application's .local directory so that future attempts to request this album's artwork do not have to make additional calls to the Last.fm API.  A callback is then called to update the displayed image with the newly downloaded artwork.  I ran into an issue in FileIO related to QDataStream, it seems to append 4 bytes of QDataStream header to the output file which was rendering downloaded .jpg files unviewable.  I got rid of QDataStream and that fixed it, but please ensure this doesn't break other intended functionality.