### PR TITLE
Fix issues with special/non-ASCII characters in filenames

### DIFF
--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -66,8 +66,8 @@ QString FileIO::findFilePath(const QString &source)
     {
         QFile f(cacheDir + d.entryList()[0]);
         if (f.exists()) {
-            qDebug() << QLatin1String(f.filesystemFileName().c_str());
-            return QLatin1String(f.filesystemFileName().c_str());
+            qDebug() << QString::fromUtf8(f.filesystemFileName().c_str());
+            return QString::fromUtf8(f.filesystemFileName().c_str());
         }
     }
     return QString();
@@ -83,8 +83,8 @@ QString FileIO::filePath(const QString &source)
 
     QFile f(cacheDir + source);
     if (f.exists()) {
-        qDebug() << QLatin1String(f.filesystemFileName().c_str());
-        return QLatin1String(f.filesystemFileName().c_str());
+        qDebug() << QString::fromUtf8(f.filesystemFileName().c_str());
+        return QString::fromUtf8(f.filesystemFileName().c_str());
     }
     return QString();
 }


### PR DESCRIPTION
I was having some album artworks downloaded from Last.fm not showing up properly and noticed that it was saving them correctly but not able to recall them from the cache.  Filenames such as:

"Eminem_The Death of Slim Shady Coup De Grâce Expanded Mourner’s Edition.jpg"

and

"Lynyrd Skynyrd_Pronounced Leh-Nérd Skin-Nérd.jpg"

were being mangled because of the special characters (apostrophe included).  I tracked this down to the use of QLatin1String.  Replacing it with a UTF8 string fixes the mangled characters and allows the artwork from these files to be loaded properly.